### PR TITLE
fix: delete state spec in ContainerInstance model

### DIFF
--- a/src/spaceone/inventory/manager/container_instances/container_manager.py
+++ b/src/spaceone/inventory/manager/container_instances/container_manager.py
@@ -68,7 +68,6 @@ class ContainerInstancesManager(AzureManager):
                 container_instance_resource = ContainerInstanceResource({
                     'name': container_instance_data.name,
                     'account': container_instance_dict['subscription_id'],
-                    'state': container_instance_data.instance_view.state,
                     'data': container_instance_data,
                     'tags': _tags,
                     'region_code': container_instance_data.location

--- a/src/spaceone/inventory/model/container_instances/cloud_service.py
+++ b/src/spaceone/inventory/model/container_instances/cloud_service.py
@@ -72,7 +72,6 @@ class ContainerInstanceResource(ContainerResource):
     account = StringType(serialize_when_none=False)
     instance_type = StringType(serialize_when_none=False)
     instance_size = FloatType(serialize_when_none=False)
-    state = StringType(serialize_when_none=False)
 
 
 class ContainerInstanceResponse(CloudServiceResponse):

--- a/src/spaceone/inventory/model/container_instances/cloud_service_type.py
+++ b/src/spaceone/inventory/model/container_instances/cloud_service_type.py
@@ -30,7 +30,6 @@ cst_container_instances.tags = {
 
 cst_container_instances._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
-        TextDyField.data_source('Container Group Name', 'name'),
         TextDyField.data_source('Status', 'state'),
         TextDyField.data_source('Resource Group', 'data.resource_group'),
         TextDyField.data_source('OS type', 'data.os_type'),


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- delete state spec in ContainerInstance model because of this error 
```
Database query failed. (reason = ValidationError (CloudService:None) (Value must be one of (ACTIVE, DISCONNECTED, DELETED): [state]))
```
### Known issue
* #14 