### PR TITLE
fix: add reference info in Raw Data for identify each cloud resource

### DIFF
--- a/src/spaceone/inventory/manager/container_instances/container_manager.py
+++ b/src/spaceone/inventory/manager/container_instances/container_manager.py
@@ -6,6 +6,7 @@ from spaceone.inventory.model.container_instances.cloud_service import *
 from spaceone.inventory.model.container_instances.cloud_service_type import CLOUD_SERVICE_TYPES
 from spaceone.inventory.model.container_instances.data import *
 from spaceone.inventory.libs.schema.base import ReferenceModel
+from spaceone.core.utils import *
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +54,11 @@ class ContainerInstancesManager(AzureManager):
                 time.sleep(0.2)  # end code
 
                 # Update data info in Container's Raw Data
+                for container in container_instance_dict['containers']:
+                    start_time = container['instance_view']['current_state']['start_time']
+                    if start_time is not None:
+                        container_instance_dict['time_created'] = datetime_to_iso8601(start_time)
+
                 container_instance_dict.update({
                     'resource_group': self.get_resource_group_from_id(container_instance_id),
                     'subscription_id': subscription_info['subscription_id'],

--- a/src/spaceone/inventory/manager/container_instances/container_manager.py
+++ b/src/spaceone/inventory/manager/container_instances/container_manager.py
@@ -5,6 +5,7 @@ from spaceone.inventory.connector.container_instances import ContainerInstancesC
 from spaceone.inventory.model.container_instances.cloud_service import *
 from spaceone.inventory.model.container_instances.cloud_service_type import CLOUD_SERVICE_TYPES
 from spaceone.inventory.model.container_instances.data import *
+from spaceone.inventory.libs.schema.base import ReferenceModel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +30,6 @@ class ContainerInstancesManager(AzureManager):
         """
 
         _LOGGER.debug(f'** Container Instances START **')
-
         start_time = time.time()
         subscription_info = params['subscription_info']
 
@@ -70,7 +70,8 @@ class ContainerInstancesManager(AzureManager):
                     'account': container_instance_dict['subscription_id'],
                     'data': container_instance_data,
                     'tags': _tags,
-                    'region_code': container_instance_data.location
+                    'region_code': container_instance_data.location,
+                    'reference': ReferenceModel(container_instance_data.reference())
                 })
 
                 self.set_region_code(container_instance_data['location'])

--- a/src/spaceone/inventory/model/container_instances/cloud_service.py
+++ b/src/spaceone/inventory/model/container_instances/cloud_service.py
@@ -17,7 +17,7 @@ container_instances_info_meta = ItemDynamicLayout.set_fields('Container Instance
     TextDyField.data_source('Subscription', 'data.subscription_name'),
     TextDyField.data_source('Subscription ID', 'account'),
     TextDyField.data_source('SKU', 'data.sku'),
-    TextDyField.data_source('OS type', 'data'),
+    TextDyField.data_source('OS type', 'data.os_type'),
     TextDyField.data_source('Container count', 'data.container_count_display'),
     TextDyField.data_source('IP Address', 'data.ip_address.ip'),
     TextDyField.data_source('IP Address Type', 'data.ip_address.type'),
@@ -28,9 +28,9 @@ container_instances_info_meta = ItemDynamicLayout.set_fields('Container Instance
 ])
 
 # TAB -Container
-container_instances_info_container = TableDynamicLayout.set_fields('Containers', 'data', fields=[
+container_instances_info_container = TableDynamicLayout.set_fields('Containers', root_path='data', fields=[
     TextDyField.data_source('Name', 'containers.name'),
-    TextDyField.data_source('Container Instance', 'name'),
+    TextDyField.data_source('Container Instance Name', 'name'),
     TextDyField.data_source('Image', 'containers.image'),
     TextDyField.data_source('State', 'containers.instance_view.current_state.state'),
     TextDyField.data_source('Start time', 'containers.instance_view.current_state.start_time'),
@@ -47,7 +47,7 @@ container_instances_info_container = TableDynamicLayout.set_fields('Containers',
 ])
 
 # TAB - Volume
-container_instances_info_volumes = TableDynamicLayout.set_fields('Volumes', 'data', fields=[
+container_instances_info_volumes = TableDynamicLayout.set_fields('Volumes', root_path='data', fields=[
     TextDyField.data_source('Name', 'volumes.name'),
     TextDyField.data_source('Container Instance', 'name'),
     TextDyField.data_source('Volume type', 'containers.volume_mounts.name'),

--- a/src/spaceone/inventory/model/container_instances/cloud_service_type.py
+++ b/src/spaceone/inventory/model/container_instances/cloud_service_type.py
@@ -30,7 +30,7 @@ cst_container_instances.tags = {
 
 cst_container_instances._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
-        TextDyField.data_source('Status', 'state'),
+        TextDyField.data_source('Status', 'data.instance_view.state'),
         TextDyField.data_source('Resource Group', 'data.resource_group'),
         TextDyField.data_source('OS type', 'data.os_type'),
         TextDyField.data_source('Total Containers', 'data.container_count_display'),
@@ -50,11 +50,13 @@ cst_container_instances._metadata = CloudServiceTypeMeta.set_meta(
         }),
         TextDyField.data_source('FQDN', 'data.ip_address.fqdn', options={
             'is_optional': True
-        })
+        }),
+        TextDyField.data_source('Launched', 'data.time_created', options={
+            'is_optional': True})
     ],
     search=[
         SearchField.set(name='Container Group Name', key='name'),
-        SearchField.set(name='Status', key='state'),
+        SearchField.set(name='Status', key='data.instance_view.state'),
         SearchField.set(name='Resource Group', key='data.resource_group'),
         SearchField.set(name='OS type', key='data.os_type'),
         SearchField.set(name='Total Containers', key='data.container_count_display'),
@@ -64,6 +66,7 @@ cst_container_instances._metadata = CloudServiceTypeMeta.set_meta(
         SearchField.set(name='Restart Policy', key='data.restart_policy'),
         SearchField.set(name='IP Address', key='data.ip_address.ip'),
         SearchField.set(name='FQDN', key='data.ip_address.fqdn'),
+        SearchField.set(name='Launched', key='data.time_created')
     ],
     widget=[
         ChartWidget.set(**get_data_from_yaml(container_instances_count_by_account_conf)),
@@ -72,7 +75,7 @@ cst_container_instances._metadata = CloudServiceTypeMeta.set_meta(
         CardWidget.set(**get_data_from_yaml(container_instances_total_count_conf)),
         CardWidget.set(**get_data_from_yaml(container_instances_total_container_conf)),
         CardWidget.set(**get_data_from_yaml(container_instances_total_vcpu_conf)),
-        CardWidget.set(**get_data_from_yaml(container_instances_total_gpu_conf)),
+        CardWidget.set(**get_data_from_yaml(container_instances_total_memory_conf)),
         CardWidget.set(**get_data_from_yaml(container_instances_total_gpu_conf))
     ]
 )

--- a/src/spaceone/inventory/model/container_instances/data.py
+++ b/src/spaceone/inventory/model/container_instances/data.py
@@ -236,7 +236,7 @@ class ContainerInstance(AzureCloudService):  # Main Class
     provisioning_state = StringType(serialize_when_none=False)
     containers = ListType(ModelType(Container), serialize_when_none=False)
     image_registry_credentials = ListType(ModelType(ImageRegistryCredential), serialize_when_none=False)
-    restart_policy = StringType(choices=('ALWAYS', 'NEVER', 'ON_FAILURE'))
+    restart_policy = StringType(choices=('ALWAYS', 'NEVER', 'ON_FAILURE'), serialize_when_none=False)
     ip_address = ModelType(IpAddress, serialize_when_none=False)
     os_type = StringType(choices=('LINUX', 'WINDOWS'))
     volumes = ListType(ModelType(Volume), serialize_when_none=False)
@@ -251,6 +251,7 @@ class ContainerInstance(AzureCloudService):  # Main Class
     type = StringType(serialize_when_none=False)
     zones = ListType(StringType, serialize_when_none=False)
     container_count_display = IntType(serialize_when_none=False)
+    time_created = DateTimeType(serialize_when_none=False)
 
     def reference(self):
         return {

--- a/src/spaceone/inventory/model/container_instances/widget/container_instances_total_container_count.yaml
+++ b/src/spaceone/inventory/model/container_instances/widget/container_instances_total_container_count.yaml
@@ -7,7 +7,7 @@ query:
     - group:
         fields:
           - name: value
-            key: data.containers
+            key: data.container_count_display
             operator: sum
 options:
   value_options:

--- a/src/spaceone/inventory/model/container_instances/widget/container_instances_total_gpu_count.yaml
+++ b/src/spaceone/inventory/model/container_instances/widget/container_instances_total_gpu_count.yaml
@@ -4,6 +4,8 @@ cloud_service_type: Container
 name: Total Gpu Count
 query:
   aggregate:
+    - unwind:
+        path: data.containers
     - group:
         fields:
           - name: value

--- a/src/spaceone/inventory/model/container_instances/widget/container_instances_total_memory_size.yaml
+++ b/src/spaceone/inventory/model/container_instances/widget/container_instances_total_memory_size.yaml
@@ -4,6 +4,8 @@ cloud_service_type: Container
 name: Total Memory Size
 query:
   aggregate:
+    - unwind:
+        path: data.containers
     - group:
         fields:
           - name: value

--- a/src/spaceone/inventory/model/container_instances/widget/container_instances_total_vcpu_count.yaml
+++ b/src/spaceone/inventory/model/container_instances/widget/container_instances_total_vcpu_count.yaml
@@ -4,6 +4,8 @@ cloud_service_type: Container
 name: Total vCPU Count
 query:
   aggregate:
+    - unwind:
+        path: data.containers
     - group:
         fields:
           - name: value


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- add reference info in Raw Data for identify each cloud resource
  - in Raw Data reference.resource_id is null so all `Container Instances` resources recognized same
- update widget for Container Instances
  - fix yaml file for CardChart
### Known issue
* #14 
