### PR TITLE
fix: NetworkSecurityGroups NoneType error (#27)

### DIFF
--- a/src/spaceone/inventory/manager/network_security_groups/instance_manager.py
+++ b/src/spaceone/inventory/manager/network_security_groups/instance_manager.py
@@ -230,10 +230,9 @@ class NetworkSecurityGroupsManager(AzureManager):
     @staticmethod
     def get_virtual_machine_name(network_interfaces, network_security_group_id):
         virtual_machine_name = None
-
         for network_interface in network_interfaces:
-            if network_interface['network_security_group']['id'].split('/')[-1] == network_security_group_id.split('/')[-1]:
-                virtual_machine_name = network_interface['virtual_machine']['id'].split('/')[-1]
-                return virtual_machine_name
+            if _network_security_group := network_interface['network_security_group']:
+                if _network_security_group['id'].split('/')[-1] == network_security_group_id.split('/')[-1]:
+                    return virtual_machine_name
         return virtual_machine_name
 


### PR DESCRIPTION
Signed-off-by: Minho Kim <mino@megazone.co.kr>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- fix: NetworkSecurityGroups NoneType error
  - In this case `network_interface['network_security_group']` sometimes has a `None` value so i changed logic.
  
### Known issue
* #27 
