### PR TITLE
fix: change collect Hub for Web PubSub Service and fix typo

### DIFF
--- a/src/spaceone/inventory/manager/web_pubsub_service/service_manager.py
+++ b/src/spaceone/inventory/manager/web_pubsub_service/service_manager.py
@@ -62,7 +62,7 @@ class WebPubSubServiceManager(AzureManager):
                 web_pubsub_hubs = web_pubsub_service_conn.list_hubs(resource_group_name=resource_group_name,
                                                                     resource_name=resource_name)
 
-                _hub_responses, _hub_errors = self._collect_web_pubsub_hub(web_pubsub_hubs, subscription_info, web_pubsub_service_dict['location'])
+                _hub_responses, _hub_errors = self._collect_web_pubsub_hub(copy.deepcopy(web_pubsub_hubs), subscription_info, web_pubsub_service_dict['location'])
                 web_pubsub_responses.extend(_hub_responses)
                 error_responses.extend(_hub_errors)
 

--- a/src/spaceone/inventory/manager/web_pubsub_service/service_manager.py
+++ b/src/spaceone/inventory/manager/web_pubsub_service/service_manager.py
@@ -59,16 +59,15 @@ class WebPubSubServiceManager(AzureManager):
                             private_endpoint['private_endpoint']['id'])
 
                 # Collect Web PubSub Hub resource
-                web_pubsub_hubs = web_pubsub_service_conn.list_hubs(resource_group_name=resource_group_name,
-                                                                    resource_name=resource_name)
+                web_pubsub_hubs = web_pubsub_service_conn.list_hubs(resource_group_name=resource_group_name, resource_name=resource_name)
+                web_pubsub_hubs_dict = [self.convert_nested_dictionary(hub) for hub in web_pubsub_hubs]
 
-                _hub_responses, _hub_errors = self._collect_web_pubsub_hub(copy.deepcopy(web_pubsub_hubs), subscription_info, web_pubsub_service_dict['location'])
+                _hub_responses, _hub_errors = self._collect_web_pubsub_hub(web_pubsub_hubs_dict, subscription_info, web_pubsub_service_dict['location'])
                 web_pubsub_responses.extend(_hub_responses)
                 error_responses.extend(_hub_errors)
 
                 # Add Web PubSub Hub info in data
-                web_pubsub_hub_datas = [WebPubSubHub(self.convert_nested_dictionary(hub), strict=False) for hub in
-                                        web_pubsub_hubs]
+                web_pubsub_hub_datas = [WebPubSubHub(hub_dict, strict=False) for hub_dict in web_pubsub_hubs_dict]
 
                 # Add Web PubSub Key info in data
                 web_pubsub_key = web_pubsub_service_conn.list_keys(resource_group_name=resource_group_name,
@@ -107,16 +106,15 @@ class WebPubSubServiceManager(AzureManager):
         _LOGGER.debug(f'** Web PubSub Service Finished {time.time() - start_time} Seconds **')
         return web_pubsub_responses, error_responses
 
-    def _collect_web_pubsub_hub(self, web_pubsub_hubs, subscription_info, location):
+    def _collect_web_pubsub_hub(self, web_pubsub_hubs_dict, subscription_info, location):
         web_pubsub_hub_responses = []
         error_responses = []
-        for web_pubsub_hub in web_pubsub_hubs:
+        for web_pubsub_hub_dict in web_pubsub_hubs_dict:
             web_pubsub_hub_id = ''
             try:
-                web_pubsub_hub_id = web_pubsub_hub.id
+                web_pubsub_hub_id = web_pubsub_hub_dict['id']
                 resource_group_name = self.get_resource_group_from_id(web_pubsub_hub_id)
 
-                web_pubsub_hub_dict = self.convert_nested_dictionary(web_pubsub_hub)
                 web_pubsub_hub_dict.update({
                     'location': location,
                     'resource_group': resource_group_name,

--- a/src/spaceone/inventory/model/web_pubsub_service/cloud_service.py
+++ b/src/spaceone/inventory/model/web_pubsub_service/cloud_service.py
@@ -24,7 +24,7 @@ web_pubsub_svc_info_meta = ItemDynamicLayout.set_fields('Web PubSub Service', fi
     TextDyField.data_source('Region', 'data.location'),
     TextDyField.data_source('Hub count', 'data.web_pubsub_hub_count_display'),
     TextDyField.data_source('SKU', 'data.sku.tier'),
-    TextDyField.data_source('Unit', 'data.sku.unit'),
+    TextDyField.data_source('Unit', 'data.sku.capacity'),
     TextDyField.data_source('Version', 'data.version'),
     TextDyField.data_source('Host name', 'data.host_name'),
     TextDyField.data_source('Host name prefix', 'data.host_name_prefix'),
@@ -80,7 +80,7 @@ shared_private_endpoints_private_access = TableDynamicLayout.set_fields('Shared 
     TextDyField.data_source('Name', 'name'),
     TextDyField.data_source('Private link resource ID', 'private_link_resource_id'),
     TextDyField.data_source('Group ID', 'group_id'),
-    EnumDyField.data_source('Connection state', 'status', efault_state={
+    EnumDyField.data_source('Connection state', 'status', default_state={
         'safe': ['Approved'],
         'warning': ['Pending'],
         'alert': ['Disconnected', 'Rejected'],
@@ -99,17 +99,17 @@ default_action_access_control_rules = ItemDynamicLayout.set_fields('Default acti
 ])
 
 public_network_access_control_rules = ItemDynamicLayout.set_fields('Public network', fields=[
-    ListDyField.data_source('Allow', 'data.public_network.allow', options={'delimiter': ','})
+    ListDyField.data_source('Allow', 'data.public_network.allow', options={'delimiter': ', '})
 ])
 
 private_endpoint_connections_access_control_rules = TableDynamicLayout.set_fields('Private endpoint connections',
                                                                                   root_path='data.network_ac_ls.private_endpoints' ,fields=[
         TextDyField.data_source('Connection name', 'name'),
-        ListDyField.data_source('Allow', 'allow',  options={'delimiter': ','})
+        ListDyField.data_source('Allow', 'allow',  options={'delimiter': ', '})
     ])
 
 web_pubsub_svc_access_control_rules_info = ListDynamicLayout.set_layouts(' Access control rules', layouts=[
-    default_action_access_control_rules, default_action_access_control_rules,
+    default_action_access_control_rules, public_network_access_control_rules,
     private_endpoint_connections_access_control_rules
 ])
 

--- a/src/spaceone/inventory/model/web_pubsub_service/cloud_service_type.py
+++ b/src/spaceone/inventory/model/web_pubsub_service/cloud_service_type.py
@@ -17,8 +17,8 @@ web_pubsub_svc_count_by_region_conf = os.path.join(current_dir, 'widget/web_pubs
 web_pubsub_svc_count_by_resource_group_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_count_by_resource_group.yaml')
 web_pubsub_svc_count_by_account_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_count_by_account.yaml')
 web_pubsub_svc_total_count_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_total_count.yaml')
-web_pubsub_svc_total_unit_count_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_unit_count_by_tier.yaml')
-web_pubsub_svc_unit_count_by_tier_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_total_unit_count.yaml')
+web_pubsub_svc_total_unit_count_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_total_unit_count.yaml')
+web_pubsub_svc_unit_count_by_tier_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_unit_count_by_tier.yaml')
 
 cst_web_pubsub_svc = CloudServiceTypeResource()
 cst_web_pubsub_svc.name = 'Service'

--- a/src/spaceone/inventory/model/web_pubsub_service/cloud_service_type.py
+++ b/src/spaceone/inventory/model/web_pubsub_service/cloud_service_type.py
@@ -14,7 +14,7 @@ Service
 '''
 
 web_pubsub_svc_count_by_region_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_count_by_region.yaml')
-web_pubsub_svc_count_by_resource_group_conf = os.path.join(current_dir, 'widget/web_pubsub_hub_count_by_resource_group.yaml')
+web_pubsub_svc_count_by_resource_group_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_count_by_resource_group.yaml')
 web_pubsub_svc_count_by_account_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_count_by_account.yaml')
 web_pubsub_svc_total_count_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_total_count.yaml')
 web_pubsub_svc_total_unit_count_conf = os.path.join(current_dir, 'widget/web_pubsub_svc_unit_count_by_tier.yaml')
@@ -46,7 +46,7 @@ cst_web_pubsub_svc._metadata = CloudServiceTypeMeta.set_meta(
         TextDyField.data_source('Location', 'data.location'),
         TextDyField.data_source('Hub count', 'data.web_pubsub_hub_count_display'),
         TextDyField.data_source('SKU', 'data.sku.tier'),
-        TextDyField.data_source('Unit', 'data.sku.unit'),
+        TextDyField.data_source('Unit', 'data.sku.capacity'),
         TextDyField.data_source('Version', 'data.version', options={
             'is_optional': True
         }),
@@ -75,7 +75,7 @@ cst_web_pubsub_svc._metadata = CloudServiceTypeMeta.set_meta(
         SearchField.set('Location', key='data.location'),
         SearchField.set('Hub count', key='data.web_pubsub_hub_count_display', data_type='integer'),
         SearchField.set('SKU', key='data.sku.tier'),
-        SearchField.set('Unit', key='data.sku.unit', data_type='integer'),
+        SearchField.set('Unit', key='data.sku.capacity', data_type='integer'),
         SearchField.set('Version', key='data.version', data_type='float'),
         SearchField.set('Host name', key='data.host_name'),
         SearchField.set('Host name prefix', key='data.host_name_prefix'),


### PR DESCRIPTION
Signed-off-by: Minho Kim <mino@megazone.com>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- fix: change collect Hub for Web PubSub Service and fix typo 
  - There are two Hub categories in screenshot.
  so I have to use Hub data twice and it affect the origin `Hub` data(in `src/spaceone/inventory/manager/web_pubsub_service/service_manager.py` at line 62)
  ![image](https://user-images.githubusercontent.com/38625842/199375160-6123d327-ec78-4fa7-8e9e-727dcca4683e.png)
  I thought there are two solutions, I chose second one.
     1. one more API call
     2. deep copy for the origin data


### Known issue
