### PR TITLE
Add blob count and size info for StorageAccounts

### DIFF
--- a/src/spaceone/inventory/connector/monitor/connector.py
+++ b/src/spaceone/inventory/connector/monitor/connector.py
@@ -15,3 +15,9 @@ class MonitorConnector(AzureConnector):
 
     def list_diagnostic_settings(self, resource_uri):
         return self.monitor_client.diagnostic_settings.list(resource_uri=resource_uri)
+
+    def list_metrics(self, resource_uri, metricnames, aggregation, timespan=None, interval=None):
+        return self.monitor_client.metrics.list(resource_uri, metricnames=metricnames, aggregation=aggregation,
+                                                timespan=timespan, interval=interval)
+
+

--- a/src/spaceone/inventory/libs/manager.py
+++ b/src/spaceone/inventory/libs/manager.py
@@ -175,6 +175,8 @@ class AzureManager(BaseManager):
         cloud_svc_dict = {}
         if hasattr(cloud_svc_object, '__dict__'):  # if cloud_svc_object is not a dictionary type but has dict method
             cloud_svc_dict = cloud_svc_object.__dict__
+        elif isinstance(cloud_svc_object, dict):
+            cloud_svc_dict = cloud_svc_object
         elif not isinstance(cloud_svc_object, list):  # if cloud_svc_object is one of type like int, float, char, ...
             return cloud_svc_object
 

--- a/src/spaceone/inventory/model/storage_accounts/cloud_service.py
+++ b/src/spaceone/inventory/model/storage_accounts/cloud_service.py
@@ -24,7 +24,10 @@ storage_account_info_meta = ItemDynamicLayout.set_fields('Storage Account', fiel
     TextDyField.data_source('Replication', 'data.sku.name'),
     TextDyField.data_source('Account Kind', 'data.kind'),
     TextDyField.data_source('Provisioning State', 'data.provisioning_state'),
-    DateTimeDyField.data_source('Creation Time', 'data.creation_time')
+    DateTimeDyField.data_source('Creation Time', 'data.creation_time'),
+    TextDyField.data_source('Container count', 'data.container_count_display'),
+    TextDyField.data_source('Blob count', 'data.blob_count_display'),
+    SizeField.data_source('Blob total size', 'data.blob_size_display')
 ])
 
 # TAB - Networking
@@ -52,7 +55,7 @@ storage_account_primary_endpoints = ItemDynamicLayout.set_fields('Primary Endpoi
 ])
 
 # TAB - Containers
-storage_account_containers = TableDynamicLayout.set_fields('Containers', 'data.container_item', fields=[
+storage_account_containers = TableDynamicLayout.set_fields('Containers', 'data', fields=[
     TextDyField.data_source('Name', 'name'),
     DateTimeDyField.data_source('Last Modified', 'last_modified_time'),
     TextDyField.data_source('Public Access Level', 'public_access'),

--- a/src/spaceone/inventory/model/storage_accounts/cloud_service_type.py
+++ b/src/spaceone/inventory/model/storage_accounts/cloud_service_type.py
@@ -2,15 +2,21 @@ import os
 from spaceone.inventory.libs.utils import *
 from spaceone.inventory.libs.schema.metadata.dynamic_widget import CardWidget, ChartWidget
 from spaceone.inventory.libs.schema.metadata.dynamic_field import TextDyField, SearchField, DateTimeDyField, ListDyField, \
-    EnumDyField
+    SizeField
 from spaceone.inventory.libs.schema.cloud_service_type import CloudServiceTypeResource, CloudServiceTypeResponse, \
     CloudServiceTypeMeta
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
 
+storage_accounts_blob_count_by_account_conf = os.path.join(current_dir, 'widget/storage_accounts_blob_count_by_account.yaml')
+storage_accounts_blob_count_by_region_conf = os.path.join(current_dir, 'widget/storage_accounts_blob_count_by_region.yaml')
+storage_accounts_blob_size_by_account_conf = os.path.join(current_dir, 'widget/storage_accounts_blob_size_by_account.yaml')
+storage_accounts_blob_size_by_resource_group_conf = os.path.join(current_dir, 'widget/storage_accounts_blob_size_by_resource_group.yaml')
 storage_accounts_count_by_account_conf = os.path.join(current_dir, 'widget/storage_accounts_count_by_account.yaml')
 storage_accounts_count_by_region_conf = os.path.join(current_dir, 'widget/storage_accounts_count_by_region.yaml')
-storage_accounts_count_by_subscription_conf = os.path.join(current_dir, 'widget/storage_accounts_count_by_subscription.yaml')
+storage_accounts_count_by_resource_group_conf = os.path.join(current_dir, 'widget/storage_accounts_count_by_resource_group.yaml')
+storage_accounts_total_blob_count_conf = os.path.join(current_dir, 'widget/storage_accounts_total_blob_count.yaml')
+storage_accounts_total_blob_size_conf = os.path.join(current_dir, 'widget/storage_accounts_total_blob_size.yaml')
 storage_accounts_total_count_conf = os.path.join(current_dir, 'widget/storage_accounts_total_count.yaml')
 
 cst_storage_accounts = CloudServiceTypeResource()
@@ -26,11 +32,15 @@ cst_storage_accounts.tags = {
 
 cst_storage_accounts._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
-        TextDyField.data_source('Type', 'data.type'),
+        SizeField.data_source('Container count', 'data.container_count_display'),
+        SizeField.data_source('Blob count', 'data.blob_count_display'),
+        SizeField.data_source('Blob total size', 'data.container_size_display'),
         TextDyField.data_source('Resource Group', 'data.resource_group'),
         TextDyField.data_source('Location', 'data.location'),
         TextDyField.data_source('Subscription ID', 'account'),
         TextDyField.data_source('Subscription Name', 'data.subscription_name'),
+        TextDyField.data_source('SKU', 'data.sku.name'),
+        TextDyField.data_source('Type', 'data.type'),
         TextDyField.data_source('State of Primary', 'data.status_of_primary', options={
             'is_optional': True
         }),
@@ -117,11 +127,15 @@ cst_storage_accounts._metadata = CloudServiceTypeMeta.set_meta(
         })
     ],
     search=[
-        SearchField.set(name='Type', key='data.type'),
+        SearchField.set(name='Container count', key='data.container_count_display', data_type='integer'),
+        SearchField.set(name='Blob count', key='data.blob_count_display', data_type='integer'),
+        SearchField.set(name='Blob total size(Bytes)', key='data.container_size_display', data_type='integer'),
         SearchField.set(name='Subscription ID', key='account'),
         SearchField.set(name='Subscription Name', key='data.subscription_name'),
         SearchField.set(name='Resource Group', key='data.resource_group'),
         SearchField.set(name='Location', key='data.location'),
+        SearchField.set(name='SKU', key='data.sku.name'),
+        SearchField.set(name='Type', key='data.type'),
         SearchField.set(name='State of Primary', key='data.status_of_primary'),
         SearchField.set(name='Performance Tier', key='instance_type'),
         SearchField.set(name='Access Tier', key='data.access_tier'),
@@ -152,10 +166,17 @@ cst_storage_accounts._metadata = CloudServiceTypeMeta.set_meta(
         SearchField.set(name='Secondary Location', key='data.secondary_location'),
     ],
     widget=[
-        ChartWidget.set(**get_data_from_yaml(storage_accounts_count_by_account_conf)),
         ChartWidget.set(**get_data_from_yaml(storage_accounts_count_by_region_conf)),
-        ChartWidget.set(**get_data_from_yaml(storage_accounts_count_by_subscription_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_count_by_resource_group_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_count_by_account_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_blob_count_by_account_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_blob_count_by_region_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_blob_size_by_resource_group_conf)),
+        ChartWidget.set(**get_data_from_yaml(storage_accounts_blob_size_by_account_conf)),
         CardWidget.set(**get_data_from_yaml(storage_accounts_total_count_conf)),
+        CardWidget.set(**get_data_from_yaml(storage_accounts_total_blob_count_conf)),
+        CardWidget.set(**get_data_from_yaml(storage_accounts_total_blob_size_conf)),
+
     ]
 )
 

--- a/src/spaceone/inventory/model/storage_accounts/data.py
+++ b/src/spaceone/inventory/model/storage_accounts/data.py
@@ -1,5 +1,5 @@
 from schematics import Model
-from schematics.types import ModelType, ListType, StringType, IntType, BooleanType, DateTimeType, DictType
+from schematics.types import ModelType, ListType, StringType, IntType, BooleanType, DateTimeType, DictType, FloatType
 from spaceone.inventory.libs.schema.resource import AzureCloudService
 
 
@@ -229,10 +229,18 @@ class Sku(Model):
 
 
 class ContainerItem(Model):
+    id = StringType(serialize_when_none=False)
     name = StringType(serialize_when_none=False)
-    last_modified_time = DateTimeType(serialize_when_none=False)
+    type = StringType(serialize_when_none=False)
+    etag = StringType(serialize_when_none=False)
+    version = StringType(serialize_when_none=False)
+    deleted = BooleanType(serialize_when_none=False)
+    deleted_time = DateTimeType(serialize_when_none=False)
+    remaining_retention_days = IntType(serialize_when_none=False)
     public_access = StringType(serialize_when_none=False)
+    last_modified_time = DateTimeType(serialize_when_none=False)
     lease_state = StringType(serialize_when_none=False)
+    metadata = DictType(StringType)
 
 
 class StorageAccount(AzureCloudService):
@@ -278,6 +286,9 @@ class StorageAccount(AzureCloudService):
     supports_https_traffic_only = BooleanType(serialize_when_none=False)
     sku = ModelType(Sku, serialize_when_none=False)
     type = StringType(serialize_when_none=False)
+    blob_size_display = FloatType(default=0.0)
+    blob_count_display = IntType(default=0)
+    container_count_display = IntType(default=0)
 
     def reference(self):
         return {

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_count_by_account.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_count_by_account.yaml
@@ -1,7 +1,7 @@
 ---
 cloud_service_group: StorageAccounts
 cloud_service_type: Instance
-name: Total Count by Subscription
+name: Blob Count By Account
 query:
   aggregate:
     - group:
@@ -10,7 +10,11 @@ query:
             key: account
         fields:
           - name: value
-            key: account
-            operator: count
+            key: data.blob_count_display
+            operator: sum
+  filter:
+    - key: account
+      value: true
+      operator: exists
 options:
   chart_type: DONUT

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_count_by_region.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_count_by_region.yaml
@@ -1,0 +1,20 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Blob Count By Region
+query:
+  aggregate:
+    - group:
+        keys:
+          - name: name
+            key: account
+        fields:
+          - name: value
+            key: data.blob_count_display
+            operator: sum
+  filter:
+    - key: account
+      value: true
+      operator: exists
+options:
+  chart_type: DONUT

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_size_by_account.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_size_by_account.yaml
@@ -1,0 +1,23 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Blob Size By Account
+query:
+  aggregate:
+    - group:
+        keys:
+          - name: name
+            key: account
+        fields:
+          - name: value
+            key: data.blob_size_display
+            operator: sum
+  filter:
+    - key: account
+      value: true
+      operator: exists
+options:
+  chart_type: DONUT
+  value_options:
+    key: value
+    type: size

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_size_by_resource_group.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_blob_size_by_resource_group.yaml
@@ -1,0 +1,24 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Blob Size by Region
+query:
+  aggregate:
+    - group:
+        keys:
+          - name: name
+            key: region_code
+        fields:
+          - name: value
+            key: data.blob_size_display
+            operator: sum
+options:
+  chart_type: COLUMN
+  name_options:
+    key: name
+    reference:
+      resource_type: "inventory.Region"
+      reference_key: region_code
+  value_options:
+    key: value
+    type: size

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_count_by_resource_group.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_count_by_resource_group.yaml
@@ -1,0 +1,15 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Count by Resource Group
+query:
+  aggregate:
+    - group:
+        keys:
+          - name: name
+            key: data.resource_group
+        fields:
+          - name: value
+            operator: count
+options:
+  chart_type: DONUT

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_total_blob_count.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_total_blob_count.yaml
@@ -1,0 +1,16 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Total Blob Count
+query:
+  aggregate:
+    - group:
+        fields:
+          - name: value
+            key: data.blob_count_display
+            operator: sum
+options:
+  value_options:
+    key: value
+    options:
+      default: 0

--- a/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_total_blob_size.yaml
+++ b/src/spaceone/inventory/model/storage_accounts/widget/storage_accounts_total_blob_size.yaml
@@ -1,0 +1,17 @@
+---
+cloud_service_group: StorageAccounts
+cloud_service_type: Instance
+name: Total Blob Size
+query:
+  aggregate:
+    - group:
+        fields:
+          - name: value
+            key: data.blob_size_display
+            operator: sum
+options:
+  value_options:
+    key: value
+    type: size
+    options:
+      default: 0


### PR DESCRIPTION
Signed-off-by: Minho Kim <mino@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- add blob count and size info for StorageAccounts
  - add `Container count`, `Blob count` and `Blob total size` info by using monitoring sdk
### Known issue
* #33 