### PR TITLE
feat: add Kubernetes Service inventory collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Please contact us if you need any further information.
 | Service                                                                  | [Web PubSub Service](#web-pubsub-service)                   |
 | Score<br>OperationalExcellence<br>Performance<br>Reliability<br>Security | [Advisor](#advisor)                                         |
 | Instance                                                                 | [Functions](#functions)                                     |
+| Instance                                                                 | [Kubernetes Service](#kubernetes-service) |
+
 
     
 ---
@@ -115,6 +117,8 @@ The following is a list of services being collected and service code information
 | 22  | Advisor                     | Microsoft.Advisor/advisorScore<br>Microsoft.ResourceHealth/events |
 | 23  | Container Registries        | Microsoft.ContainerRegistry/registries                            |
 | 24  | Functions                   | Microsoft.Web/sites                                               |
+| 25 | Kubernetes Service | Microsoft.ContainerService/ManagedClusters |
+
 
 ---
 
@@ -933,6 +937,26 @@ Deprecated)
         "Microsoft.Network/routeTables/read",
         "Microsoft.Resources/*/read"
       ```
+      
+#### [Kubernetes Service](https://learn.microsoft.com/ko-kr/python/api/azure-mgmt-containerservice/azure.mgmt.containerservice.containerserviceclient?view=azure-python)
+
+- Kubernetes Service (AKS)
+  - Scope
+    - https://learn.microsoft.com/ko-kr/python/api/azure-mgmt-containerservice/azure.mgmt.containerservice.containerserviceclient?view=azure-python
+      - managed_clusters  
+        - list()
+        - get()
+        
+    - https://learn.microsoft.com/ko-kr/python/api/azure-mgmt-resource/azure.mgmt.resource.resources.resourcemanagementclient?view=azure-python
+      - locks
+        - list_at_resource_level()
+  - Permissions
+   ```
+    "Microsoft.ContainerService/managedClusters/read"
+    "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action"
+    "Microsoft.Authorization/locks/*/read"
+    "Microsoft.Resources/subscriptions/resourceGroups/read"
+   ```
 ---
 
 ## Options
@@ -968,7 +992,8 @@ The cloud_service_types items that can be specified are as follows.
         'ContainerInstances',
         'WebPubSubService',
         "ContainerRegistries",
-        "Functions"
+        "Functions",
+        "KubernetesService"
     ]
 }
 </code>
@@ -1034,7 +1059,8 @@ The default ASSET_URL in cloud_service_conf is
 
 | Version | Description                                                                                                                                                                                                                                                                                                                                                               | Affected Service                                    | Release Date |
 |---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|--------------|
-| 2.0.9   | - Add Azure Functions, Container Registries                                                                                                      | Functions, Container Registries | 2025.12.03    |
+| 2.0.10  | - Add Kubernetes Service (AKS)                                                                                                      | Kubernetes Service (AKS) | 2025.12.09   |
+| 2.0.9   | - Add Azure Functions, Container Registries                                                                                                      | Functions, Container Registries | 2025.12.03   |
 | 2.0.8   | - Add Azure Advisor service                                                                                                                                                                                                                                                                                                                                               |                                                     |              |
 | 2.0.5   | - Add Azure Cognitive service                                                                                                                                                                                                                                                                                                                                             |                                                     |              |
 | 2.0.0   | - [Migration to spaceone framework 2.0](https://github.com/cloudforet-io/plugin-azure-inven-collector/issues/91)                                                                                                                                                                                                                                                          | All Services                                        | 2024.08.22   |

--- a/src/plugin/connector/base.py
+++ b/src/plugin/connector/base.py
@@ -9,6 +9,7 @@ from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+from azure.mgmt.containerservice import ContainerServiceClient
 from azure.mgmt.cosmosdb import CosmosDBManagementClient
 from azure.mgmt.keyvault import KeyVaultManagementClient
 from azure.mgmt.monitor import MonitorManagementClient
@@ -43,6 +44,7 @@ class AzureBaseConnector(BaseConnector):
         self.monitor_client = None
         self.container_instance_client = None
         self.container_registry_client = None
+        self.container_service_client = None
         self.resource_client = None
         self.resource_health_client = None
         self.storage_client = None
@@ -86,7 +88,9 @@ class AzureBaseConnector(BaseConnector):
         self.container_registry_client = ContainerRegistryManagementClient(
             credential=self.credential, subscription_id=subscription_id
         )
-
+        self.container_service_client = ContainerServiceClient(
+            credential=self.credential, subscription_id=subscription_id
+        )
         self.resource_client = ResourceManagementClient(
             credential=self.credential, subscription_id=subscription_id
         )

--- a/src/plugin/connector/kubernetes_services/container_service_conector.py
+++ b/src/plugin/connector/kubernetes_services/container_service_conector.py
@@ -1,0 +1,38 @@
+import logging
+
+from plugin.connector.base import AzureBaseConnector
+
+_LOGGER = logging.getLogger("spaceone")
+
+
+class ContainerServiceConnector(AzureBaseConnector):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.set_connect(kwargs.get("secret_data"))
+
+    def list_managed_cluster(self):
+        return self.container_service_client.managed_clusters.list()
+
+    def get_managed_cluster(self, resource_group_name, cluster_name):
+        return self.container_service_client.managed_clusters.get(
+            resource_group_name, cluster_name
+        )
+
+    def list_agent_pools(self, resource_group_name, cluster_name):
+        return self.container_service_client.agent_pools.list(
+            resource_group_name, cluster_name
+        )
+
+    def list_locks(self, resource_id: str):
+        url = (
+            f"https://management.azure.com{resource_id}"
+            "/providers/Microsoft.Authorization/locks"
+            "?api-version=2016-09-01"
+        )
+
+        try:
+            result = self.request_azure_api(url) or {}
+            return result.get("value", [])
+        except Exception as e:
+            _LOGGER.warning(f"[ContainerServiceConnector.list_locks] error: {e}")
+            return []

--- a/src/plugin/manager/__init__.py
+++ b/src/plugin/manager/__init__.py
@@ -25,3 +25,4 @@ from .virtual_networks import *
 from .vm_scale_sets import *
 from .web_pub_sub_service import *
 from .functions import *
+from .kubernetes_services import *

--- a/src/plugin/manager/kubernetes_services/__init__.py
+++ b/src/plugin/manager/kubernetes_services/__init__.py
@@ -1,0 +1,1 @@
+from .cluster_manager import KubernetesServiceClusterManager

--- a/src/plugin/manager/kubernetes_services/cluster_manager.py
+++ b/src/plugin/manager/kubernetes_services/cluster_manager.py
@@ -1,0 +1,328 @@
+import logging
+
+from spaceone.inventory.plugin.collector.lib import *
+from plugin.conf.cloud_service_conf import ICON_URL
+from plugin.connector.kubernetes_services.container_service_conector import (
+    ContainerServiceConnector,
+)
+from plugin.connector.subscriptions.subscriptions_connector import (
+    SubscriptionsConnector,
+)
+from plugin.manager.base import AzureBaseManager
+
+_LOGGER = logging.getLogger("spaceone")
+
+
+class KubernetesServiceClusterManager(AzureBaseManager):
+    cloud_service_group = "KubernetesService"
+    cloud_service_type = "Cluster"
+    service_code = "Microsoft.ContainerService/ManagedClusters"
+
+    def create_cloud_service_type(self):
+        return make_cloud_service_type(
+            name=self.cloud_service_type,
+            group=self.cloud_service_group,
+            provider=self.provider,
+            service_code=self.service_code,
+            metadata_path=self.get_metadata_path(),
+            is_primary=True,
+            is_major=True,
+            labels=["Kubernetes", "AKS"],
+            tags={"spaceone:icon": f"{ICON_URL}/azure-kubernetes-services.svg"},
+        )
+
+    def create_cloud_service(self, options, secret_data, schema):
+        cloud_services = []
+        error_responses = []
+
+        cs_conn = ContainerServiceConnector(secret_data=secret_data)
+        sub_conn = SubscriptionsConnector(secret_data=secret_data)
+
+        sub_raw = sub_conn.get_subscription(secret_data["subscription_id"])
+        sub_info = self.convert_nested_dictionary(sub_raw)
+
+        try:
+            clusters = cs_conn.list_managed_cluster()
+        except Exception as e:
+            _LOGGER.error(
+                f"[KubernetesServiceClusterManager] list_managed_cluster error: {e}",
+                exc_info=True,
+            )
+            error_responses.append(
+                make_error_response(
+                    error=e,
+                    provider=self.provider,
+                    cloud_service_group=self.cloud_service_group,
+                    cloud_service_type=self.cloud_service_type,
+                )
+            )
+            return cloud_services, error_responses
+
+        for cluster in clusters:
+            try:
+                cluster_dict = self.convert_nested_dictionary(cluster)
+                resource_id = cluster_dict.get("id")
+                resource_group = self.get_resource_group_from_id(resource_id)
+                location = (cluster_dict.get("location") or "").replace(" ", "").lower()
+
+                cluster_dict["resource_group"] = resource_group
+                cluster_dict["subscription_id"] = sub_info["subscription_id"]
+                cluster_dict["subscription_name"] = sub_info["display_name"]
+                cluster_dict["location"] = location
+
+                power_state = cluster_dict.get("power_state") or {}
+                cluster_dict["power_state_display"] = power_state.get("code")
+
+                fleet = cluster_dict.get("fleet") or {}
+                fleet_id = fleet.get("id")
+                cluster_dict["fleet_manager"] = (
+                    fleet.get("name") or (fleet_id.split("/")[-1] if fleet_id else None)
+                )
+
+                # Node pools  (Target nodes / Ready nodes / OS ...)
+                node_pools = []
+
+                for pool in cluster_dict.get("agent_pool_profiles") or []:
+                    auto_scaling = pool.get("enable_auto_scaling")
+
+                    power_state = (pool.get("power_state") or {}).get("code")
+                    min_count = pool.get("min_count")
+                    max_count = pool.get("max_count")
+
+                    ###TODO: target_nodes calculation is not fully accurate yet and will be improved in a future update.
+                    # power_state = (pool.get("power_state") or {}).get("code")
+                    # current_count = pool.get("count")
+                    # min_count = pool.get("min_count")
+                    # max_count = pool.get("max_count")
+                    #
+                    # # If the status is Stopped, the actual target is considered to be 0 (based on the portal Target node count).
+                    # if isinstance(power_state, str) and power_state.lower() == "stopped":
+                    #     target_nodes = 0
+                    # else:
+                    #     target_nodes = current_count
+
+                    node_pools.append(
+                        {
+                            "node_pool": pool.get("name"),
+                            "provisioning_state": pool.get("provisioning_state"),
+                            "power_state": power_state,
+                            "scale_method": "Autoscale" if auto_scaling else "Manual",
+                            ###TODO: target_nodes calculation is not fully accurate yet and will be improved in a future update.
+                            # "target_nodes": target_nodes,
+                            "min_nodes": min_count,
+                            "max_nodes": max_count,
+                            "autoscaling_status": "Enabled" if auto_scaling else "Disabled",
+                            "mode": pool.get("mode"),
+                            "operating_system": pool.get("os_type"),
+                        }
+                    )
+
+                cluster_dict["node_pools"] = node_pools
+
+                # Security configuration
+                oidc_profile = cluster_dict.get("oidc_issuer_profile") or {}
+                security_profile = cluster_dict.get("security_profile") or {}
+                aad_profile = cluster_dict.get("aad_profile") or {}
+                addon_profiles = cluster_dict.get("addon_profiles") or {}
+
+                image_cleaner = security_profile.get("image_cleaner") or {}
+                interval_hours = image_cleaner.get("interval_hours")
+
+                auth_mode = "Local accounts with Kubernetes RBAC"
+                if aad_profile.get("managed"):
+                    if aad_profile.get("enable_azure_rbac"):
+                        auth_mode = "Microsoft Entra ID authentication with Azure RBAC"
+                    else:
+                        auth_mode = "Microsoft Entra ID authentication with Kubernetes RBAC"
+
+                secret_store_addon = addon_profiles.get("azureKeyvaultSecretsProvider") or {}
+
+                cluster_dict["security_configuration"] = {
+                    "enable_oidc": oidc_profile.get("enabled"),
+                    "issuer_url": oidc_profile.get("issuer_url"),
+                    "enable_workload_identity": (
+                        (security_profile.get("workload_identity") or {}).get("enabled")
+                    ),
+                    "enable_image_cleaner": image_cleaner.get("enabled"),
+                    "scan_time_in_days": (
+                        interval_hours / 24 if isinstance(interval_hours, (int, float)) else None
+                    ),
+                    "authentication": auth_mode,
+                    "enable_secret_store_csi_driver": secret_store_addon.get("enabled"),
+                }
+
+                # Networking (Authorized IP ranges, VNet/Subnet, Cilium, Ingress …)
+                net_profile = cluster_dict.get("network_profile") or {}
+                api_profile = cluster_dict.get("api_server_access_profile") or {}
+
+                pod_cidr = net_profile.get("pod_cidr") or ", ".join(
+                    net_profile.get("podCidrs", []) or []
+                )
+                svc_cidr = net_profile.get("service_cidr") or ", ".join(
+                    net_profile.get("serviceCidrs", []) or []
+                )
+
+                ###TODO:  VNet/Subnet: Search in the order of network_profile → agent_pool_profiles
+                # vnet_subnet_id = (
+                #     net_profile.get("vnet_subnet_id")
+                #     or net_profile.get("vnetSubnetID")
+                # )
+                # if not vnet_subnet_id:
+                #     for pool in (cluster_dict.get("agent_pool_profiles") or []):
+                #         vnet_subnet_id = (
+                #             pool.get("vnet_subnet_id") or pool.get("vnetSubnetID")
+                #         )
+                #         if vnet_subnet_id:
+                #             break
+                #
+                # vnet_name = subnet_name = None
+                # if vnet_subnet_id and "/subnets/" in vnet_subnet_id:
+                #     vnet_part, subnet_part = vnet_subnet_id.split("/subnets/")
+                #     vnet_name = vnet_part.split("/")[-1]
+                #     subnet_name = subnet_part
+
+                # Public / Private access
+                public_access = (
+                    "Disabled" if api_profile.get("enable_private_cluster") else "Enabled"
+                )
+
+                # Authorized IP ranges: If not, "Not enabled"
+                auth_ip_ranges = api_profile.get("authorized_ip_ranges") or []
+                if auth_ip_ranges:
+                    authorized_ip_ranges = ", ".join(auth_ip_ranges)
+                else:
+                    authorized_ip_ranges = "Not enabled"
+
+                # Ingress controller: based on addon state, if not present, "Not enabled"
+                ingress_addon = (
+                    addon_profiles.get("ingressApplicationGateway")
+                    or addon_profiles.get("httpApplicationRouting")
+                    or {}
+                )
+                if ingress_addon.get("enabled"):
+                    ingress_controller = "Enabled"
+                else:
+                    ingress_controller = "Not enabled"
+
+                # Cilium dataplane: "Not enabled" if no value is present
+                data_plane_raw = str(net_profile.get("network_dataplane") or "")
+                if data_plane_raw.lower() == "cilium":
+                    cilium_dataplane = "Enabled"
+                else:
+                    cilium_dataplane = "Not enabled"
+
+                cluster_dict["networking"] = {
+                    "network_configuration": net_profile.get("network_plugin"),
+                    "outbound_type": net_profile.get("outbound_type"),
+                    "pod_cidr": pod_cidr,
+                    "service_cidr": svc_cidr,
+                    "dns_service_ip": net_profile.get("dns_service_ip"),
+                    "cilium_dataplane": cilium_dataplane,
+                    "network_policy_engine": net_profile.get("network_policy"),
+                    "public_access_to_api_server": public_access,
+                    "authorized_ip_ranges": authorized_ip_ranges,
+                    "load_balancer": net_profile.get("load_balancer_sku"),
+                ###TODO:  VNet/Subnet: Search in the order of network_profile → agent_pool_profiles
+                    # "virtual_network": vnet_name,
+                    # "subnet": subnet_name,
+                    "ingress_controller": ingress_controller,
+                }
+
+                # Properties
+                oms = addon_profiles.get("omsagent") or {}
+                oms_config = oms.get("config") or {}
+                http_routing = addon_profiles.get("httpApplicationRouting") or {}
+                http_cfg = http_routing.get("config") or {}
+
+                # Encryption type
+                raw_enc_type = (security_profile.get("encryption") or {}).get(
+                    "type"
+                ) or security_profile.get("encryption_type")
+                if raw_enc_type:
+                    encryption_type = raw_enc_type
+                else:
+                    encryption_type = "Encryption at rest with platform-managed key"
+
+                ###TODO: Workspace resource ID
+                # workspace_resource_id = (
+                #         oms_config.get("logAnalyticsWorkspaceResourceID")
+                #         or oms_config.get("logAnalyticsWorkspaceResourceId")
+                # )
+
+                api_server_address = (
+                        cluster_dict.get("fqdn")
+                        or (api_profile.get("private_fqdn") if api_profile else None)
+                )
+
+                cluster_dict["properties_section"] = {
+                    "kubernetes_version": cluster_dict.get("kubernetes_version"),
+                    "dns_prefix": cluster_dict.get("dns_prefix"),
+                    "api_server_address": api_server_address,
+                    "rbac": "Enabled" if cluster_dict.get("enable_rbac") else "Disabled",
+                    "encryption_type": encryption_type,
+                    ###TODO: Workspace resource ID
+                    # "workspace_resource_id": workspace_resource_id,
+                    "infrastructure_resource_group": cluster_dict.get("node_resource_group"),
+                    "http_application_routing_domain": http_cfg.get("HTTPApplicationRoutingZoneName"),
+                    "resource_id": resource_id,
+                    "location": location,
+                    "resource_group": resource_group,
+                    "subscription_id": sub_info["subscription_id"],
+                }
+
+                # Locks
+                locks_raw = cs_conn.list_locks(resource_id)
+                locks_list = []
+                for lock in locks_raw:
+                    lock_dict = self.convert_nested_dictionary(lock)
+                    props = lock_dict.get("properties") or {}
+                    lock_id = lock_dict.get("id", "")
+                    scope = lock_id.split(
+                        "/providers/Microsoft.Authorization/locks"
+                    )[0]
+                    locks_list.append(
+                        {
+                            "lock_name": lock_dict.get("name"),
+                            "lock_type": props.get("level"),
+                            "scope": scope,
+                            "notes": props.get("notes"),
+                        }
+                    )
+                cluster_dict["locks"] = locks_list
+
+                # Common
+                cluster_dict = self.update_tenant_id_from_secret_data(
+                    cluster_dict, secret_data
+                )
+                self.set_region_code(location)
+
+                cloud_services.append(
+                    make_cloud_service(
+                        name=cluster_dict.get("name"),
+                        cloud_service_type=self.cloud_service_type,
+                        cloud_service_group=self.cloud_service_group,
+                        provider=self.provider,
+                        data=cluster_dict,
+                        account=sub_info["subscription_id"],
+                        region_code=location,
+                        reference=self.make_reference(resource_id),
+                        tags=self.convert_tag_format(cluster_dict.get("tags", {})),
+                        data_format="dict",
+                    )
+                )
+
+            except Exception as e:
+                _LOGGER.error(
+                    f"[KubernetesServiceClusterManager.create_cloud_service] Error: {e}",
+                    exc_info=True,
+                )
+                error_responses.append(
+                    make_error_response(
+                        error=e,
+                        provider=self.provider,
+                        cloud_service_group=self.cloud_service_group,
+                        cloud_service_type=self.cloud_service_type,
+                    )
+                )
+
+        return cloud_services, error_responses

--- a/src/plugin/metadata/kubernetes_service/cluster.yaml
+++ b/src/plugin/metadata/kubernetes_service/cluster.yaml
@@ -1,0 +1,101 @@
+search:
+  fields:
+    - Name: name
+    - Type: data.type
+    - Subscription: data.subscription_name
+    - Subscription ID: account
+    - Resource Group: data.resource_group
+    - Location: data.location
+    - Kubernetes Version: data.kubernetes_version
+    - Fleet Manager: data.fleet_manager
+    - Power state: data.power_state_display
+
+table:
+  sort:
+    key: name
+    desc: false
+  fields:
+    - Type: data.type
+    - Subscription: data.subscription_name
+    - Subscription ID: data.subscription_id
+    - Resource Group: data.resource_group
+    - Location: data.location
+    - Kubernetes Version: data.kubernetes_version
+    - Fleet Manager: data.fleet_manager
+    - Power state: data.power_state_display
+
+tabs.0:
+  name: Node pools
+  type: table
+  root_path: data.node_pools
+  fields:
+    - Node pool: node_pool
+    - Provisioning state: provisioning_state
+    - Power state: power_state
+    - Scale method: scale_method
+###TODO: target_nodes calculation is not fully accurate yet and will be improved in a future update.
+#    - Target nodes: target_nodes
+    - Min nodes: min_nodes
+    - Max nodes: max_nodes
+    - Autoscaling status: autoscaling_status
+    - Mode: mode
+    - Operating system: operating_system
+
+tabs.1:
+  name: Security configuration
+  type: item
+  fields:
+    - Enable OIDC: data.security_configuration.enable_oidc
+    - Issuer URL: data.security_configuration.issuer_url
+    - Enable Workload Identity: data.security_configuration.enable_workload_identity
+    - Enable Image Cleaner: data.security_configuration.enable_image_cleaner
+    - Scan time (in days): data.security_configuration.scan_time_in_days
+    - Authentication: data.security_configuration.authentication
+    - Enable secret store CSI driver: data.security_configuration.enable_secret_store_csi_driver
+
+tabs.2:
+  name: Networking
+  type: item
+  fields:
+    - Network configuration: data.networking.network_configuration
+    - Outbound type: data.networking.outbound_type
+    - Pod CIDR: data.networking.pod_cidr
+    - Service CIDR: data.networking.service_cidr
+    - DNS service IP: data.networking.dns_service_ip
+    - Cilium dataplane: data.networking.cilium_dataplane
+    - Network policy engine: data.networking.network_policy_engine
+    - Public access to API server: data.networking.public_access_to_api_server
+    - Authorized IP ranges: data.networking.authorized_ip_ranges
+    - Load balancer: data.networking.load_balancer
+    ###TODO:  VNet/Subnet
+#    - Virtual network: data.networking.virtual_network
+#    - Subnet: data.networking.subnet
+    - Ingress controller: data.networking.ingress_controller
+
+tabs.3:
+  name: Properties
+  type: item
+  fields:
+    - Kubernetes Version: data.properties_section.kubernetes_version
+    - DNS prefix: data.properties_section.dns_prefix
+    - API server address: data.properties_section.api_server_address
+    - RBAC: data.properties_section.rbac
+    - Encryption type: data.properties_section.encryption_type
+    ###TODO: Workspace resource ID
+#    - Workspace resource ID: data.properties_section.workspace_resource_id
+    - Infrastructure resource group: data.properties_section.infrastructure_resource_group
+    - HTTP application routing domain: data.properties_section.http_application_routing_domain
+    - Resource ID: data.properties_section.resource_id
+    - Location: data.properties_section.location
+    - Resource Group: data.properties_section.resource_group
+    - Subscription ID: data.properties_section.subscription_id
+
+tabs.4:
+  name: Locks
+  type: table
+  root_path: data.locks
+  fields:
+    - Lock name: lock_name
+    - Lock type: lock_type
+    - Scope: scope
+    - Notes: notes

--- a/src/plugin/metrics/KubernetesService/cluster/cluster_count.yaml
+++ b/src/plugin/metrics/KubernetesService/cluster/cluster_count.yaml
@@ -1,0 +1,31 @@
+---
+metric_id: metric-azure-kubernetes_service-cluster-count
+name: Cluster Count
+metric_type: GAUGE
+resource_type: inventory.CloudService:azure.KubernetesService.Cluster
+query_options:
+  group_by:
+    - key: region_code
+      name: Region
+      reference:
+        resource_type: inventory.Region
+        reference_key: region_code
+    - key: data.tenant_id
+      name: Tenant ID
+    - key: data.subscription_name
+      name: Subscription Name
+    - key: account
+      name: Subscription ID
+    - key: data.resource_group
+      name: Resource Group
+    - key: data.power_state_display
+      name: Power state
+      default: true
+    - key: data.kubernetes_version
+      name: Kubernetes Version
+  fields:
+    value:
+      operator: count
+unit: Count
+namespace_id: ns-azure-kubernetes_service-cluster
+version: '1.0'

--- a/src/plugin/metrics/KubernetesService/cluster/namespace.yaml
+++ b/src/plugin/metrics/KubernetesService/cluster/namespace.yaml
@@ -1,0 +1,8 @@
+---
+namespace_id: ns-azure-kubernetes_service-cluster
+name: KubernetesService/Cluster
+category: ASSET
+resource_type: inventory.CloudService:azure.KubernetesService.Cluster
+group: azure
+icon: https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/azure/aks.svg
+version: '1.0'

--- a/src/setup.py
+++ b/src/setup.py
@@ -34,6 +34,7 @@ setup(
         "spaceone-api",
         "azure-identity",
         "azure-mgmt-resource",
+        "azure-mgmt-containerservice>=24.0.0",
     ],
     package_data={
         "plugin": [


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
This PR introduces Kubernetes Service (AKS) inventory collection support.
The implementation is based on the existing AKS logic from the azure-inven-v2 collector, and has been adapted to the current plugin architecture.
During the migration, metadata has been expanded and additional fields were added to reflect the Azure Portal experience and align with the latest SpaceONE inventory structure.

- Collect basic cluster info  
  (type, subscription, resource group, location, k8s version, fleet manager, power state)
- Add Node pools tab  
  (provisioning / power state, scale method, autoscaling status, min / max node count, mode, OS)
- Add Security configuration tab  
  (OIDC, issuer URL, workload identity, image cleaner, scan interval, auth mode, CSI driver)
- Add Networking tab  
  (network plugin, outbound type, Pod / Service CIDR, DNS IP, Cilium flag,  
   network policy engine, public access to API server, authorized IP ranges, LB SKU, ingress controller)
- Add Properties / Locks tabs  
  (encryption type, infra RG, HTTP routing domain, resource ID, location, lock name/type/scope/notes)

### Known issue
